### PR TITLE
Fixed a bug that leaves Windows users unaffected

### DIFF
--- a/libWiiSharp/U8.cs
+++ b/libWiiSharp/U8.cs
@@ -826,7 +826,7 @@ namespace libWiiSharp
 
                     int size = u8Nodes.Count + 2;
                     for (int j = 0; j < dirEntries.Length; j++)
-                        if (dirEntries[j].Contains(dirEntries[i] + "\\")) size++;
+                        if (dirEntries[j].Contains(dirEntries[i] + Path.DirectorySeparatorChar)) size++;
 
                     tempNode.SizeOfData = (uint)size;
                 }


### PR DESCRIPTION
Without this patch, attempting to U8 compress would place everything in the root dir of the U8 archive, generating "The system files are corrupted" errors when attempting to use the archives.